### PR TITLE
Add reply_all tool for replying to all recipients

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "auth": "node dist/index.js auth",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
@@ -60,6 +62,7 @@
   "devDependencies": {
     "@types/node": "^20.10.5",
     "@types/nodemailer": "^6.4.17",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import os from 'os';
 import {createEmailMessage, createEmailWithNodemailer} from "./utl.js";
 import { createLabel, updateLabel, deleteLabel, listLabels, findLabelByName, getOrCreateLabel, GmailLabel } from "./label-manager.js";
 import { createFilter, listFilters, getFilter, deleteFilter, filterTemplates, GmailFilterCriteria, GmailFilterAction } from "./filter-manager.js";
+import { parseEmailAddresses, filterOutEmail, addRePrefix, buildReferencesHeader, buildReplyAllRecipients } from "./reply-all-helpers.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1223,58 +1224,23 @@ async function main() {
                     const profile = await gmail.users.getProfile({ userId: 'me' });
                     const myEmail = profile.data.emailAddress?.toLowerCase() || '';
 
-                    // Helper function to parse email addresses from header value
-                    const parseEmails = (headerValue: string): string[] => {
-                        if (!headerValue) return [];
-                        // Split by comma, but handle cases like "Name <email@example.com>"
-                        const emails: string[] = [];
-                        const parts = headerValue.split(',');
-                        for (const part of parts) {
-                            const trimmed = part.trim();
-                            // Extract email from "Name <email>" format
-                            const match = trimmed.match(/<([^>]+)>/);
-                            if (match) {
-                                emails.push(match[1].trim());
-                            } else if (trimmed.includes('@')) {
-                                emails.push(trimmed);
-                            }
-                        }
-                        return emails;
-                    };
-
-                    // Helper function to filter out authenticated user's email
-                    const filterMyEmail = (emails: string[]): string[] => {
-                        return emails.filter(email => email.toLowerCase() !== myEmail);
-                    };
-
-                    // Build recipient list:
-                    // - TO: original sender (From)
-                    // - CC: original To and CC (excluding myself)
-                    const fromEmails = parseEmails(originalFrom);
-                    const toEmails = parseEmails(originalTo);
-                    const ccEmails = parseEmails(originalCc);
-
-                    // TO recipients: original From (the person who sent the email)
-                    const replyTo = filterMyEmail(fromEmails);
-
-                    // CC recipients: everyone else who was on To and CC, excluding myself
-                    const replyCc = filterMyEmail([...toEmails, ...ccEmails]);
+                    // Build recipient list using helper functions
+                    const { to: replyTo, cc: replyCc } = buildReplyAllRecipients(
+                        originalFrom,
+                        originalTo,
+                        originalCc,
+                        myEmail
+                    );
 
                     if (replyTo.length === 0) {
                         throw new Error('Could not determine recipient for reply');
                     }
 
                     // Build subject with "Re:" prefix if not already present
-                    let replySubject = originalSubject;
-                    if (!replySubject.toLowerCase().startsWith('re:')) {
-                        replySubject = `Re: ${replySubject}`;
-                    }
+                    const replySubject = addRePrefix(originalSubject);
 
                     // Build References header (original References + original Message-ID)
-                    let references = originalReferences;
-                    if (originalMessageId) {
-                        references = references ? `${references} ${originalMessageId}` : originalMessageId;
-                    }
+                    const references = buildReferencesHeader(originalReferences, originalMessageId);
 
                     // Prepare the email arguments for handleEmailAction
                     const emailArgs = {

--- a/src/reply-all-helpers.test.ts
+++ b/src/reply-all-helpers.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseEmailAddresses,
+    filterOutEmail,
+    addRePrefix,
+    buildReferencesHeader,
+    buildReplyAllRecipients
+} from './reply-all-helpers.js';
+
+describe('parseEmailAddresses', () => {
+    it('extracts email from simple email address', () => {
+        expect(parseEmailAddresses('user@example.com')).toEqual(['user@example.com']);
+    });
+
+    it('extracts email from "Name <email>" format', () => {
+        expect(parseEmailAddresses('John Doe <john@example.com>')).toEqual(['john@example.com']);
+    });
+
+    it('handles multiple addresses separated by commas', () => {
+        expect(parseEmailAddresses('alice@example.com, bob@example.com'))
+            .toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles mixed formats with multiple addresses', () => {
+        expect(parseEmailAddresses('Alice <alice@example.com>, bob@example.com, Carol Smith <carol@example.com>'))
+            .toEqual(['alice@example.com', 'bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty string', () => {
+        expect(parseEmailAddresses('')).toEqual([]);
+    });
+
+    it('handles whitespace around addresses', () => {
+        expect(parseEmailAddresses('  user@example.com  ,  other@example.com  '))
+            .toEqual(['user@example.com', 'other@example.com']);
+    });
+
+    it('handles angle brackets with spaces', () => {
+        expect(parseEmailAddresses('Name < email@example.com >')).toEqual(['email@example.com']);
+    });
+
+    it('ignores entries without @ symbol', () => {
+        expect(parseEmailAddresses('invalid, user@example.com')).toEqual(['user@example.com']);
+    });
+});
+
+describe('filterOutEmail', () => {
+    it('filters out matching email', () => {
+        const emails = ['alice@example.com', 'bob@example.com', 'carol@example.com'];
+        expect(filterOutEmail(emails, 'bob@example.com')).toEqual(['alice@example.com', 'carol@example.com']);
+    });
+
+    it('is case insensitive', () => {
+        const emails = ['Alice@Example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'alice@example.com')).toEqual(['bob@example.com']);
+    });
+
+    it('returns all emails if none match', () => {
+        const emails = ['alice@example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'carol@example.com')).toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles empty array', () => {
+        expect(filterOutEmail([], 'user@example.com')).toEqual([]);
+    });
+
+    it('handles empty filter email', () => {
+        const emails = ['alice@example.com'];
+        expect(filterOutEmail(emails, '')).toEqual(['alice@example.com']);
+    });
+});
+
+describe('addRePrefix', () => {
+    it('adds Re: prefix to subject without it', () => {
+        expect(addRePrefix('Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (lowercase)', () => {
+        expect(addRePrefix('re: Hello')).toBe('re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (uppercase)', () => {
+        expect(addRePrefix('Re: Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (mixed case)', () => {
+        expect(addRePrefix('RE: Hello')).toBe('RE: Hello');
+    });
+
+    it('handles empty subject', () => {
+        expect(addRePrefix('')).toBe('Re: ');
+    });
+
+    it('adds prefix when subject starts with similar but not Re:', () => {
+        expect(addRePrefix('Regarding: Hello')).toBe('Re: Regarding: Hello');
+    });
+});
+
+describe('buildReferencesHeader', () => {
+    it('returns message ID when no original references', () => {
+        expect(buildReferencesHeader('', '<msg123@example.com>')).toBe('<msg123@example.com>');
+    });
+
+    it('appends message ID to existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <msg123@example.com>');
+    });
+
+    it('returns empty string when both are empty', () => {
+        expect(buildReferencesHeader('', '')).toBe('');
+    });
+
+    it('returns original references when message ID is empty', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '')).toBe('<ref1@example.com>');
+    });
+
+    it('handles multiple existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com> <ref2@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <ref2@example.com> <msg123@example.com>');
+    });
+});
+
+describe('buildReplyAllRecipients', () => {
+    const myEmail = 'me@example.com';
+
+    it('puts original sender in To field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['sender@example.com']);
+    });
+
+    it('puts original To and CC in CC field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient1@example.com, recipient2@example.com',
+            'cc1@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient1@example.com', 'recipient2@example.com', 'cc1@example.com']);
+    });
+
+    it('excludes authenticated user from CC', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com, other@example.com',
+            'me@example.com, another@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com', 'another@example.com']);
+        expect(result.cc).not.toContain('me@example.com');
+    });
+
+    it('excludes authenticated user from To when sender is self', () => {
+        const result = buildReplyAllRecipients(
+            'me@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual([]);
+    });
+
+    it('handles Name <email> format in From', () => {
+        const result = buildReplyAllRecipients(
+            'John Doe <john@example.com>',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['john@example.com']);
+    });
+
+    it('handles complex scenario with mixed formats', () => {
+        const result = buildReplyAllRecipients(
+            'Alice <alice@example.com>',
+            'Me <me@example.com>, Bob <bob@example.com>',
+            'Carol <carol@example.com>, me@example.com',
+            myEmail
+        );
+        expect(result.to).toEqual(['alice@example.com']);
+        expect(result.cc).toEqual(['bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty CC header', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient@example.com']);
+    });
+
+    it('is case insensitive when excluding authenticated user', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'ME@EXAMPLE.COM, other@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com']);
+    });
+});

--- a/src/reply-all-helpers.ts
+++ b/src/reply-all-helpers.ts
@@ -1,0 +1,111 @@
+/**
+ * Helper functions for reply_all email functionality.
+ * Extracted for testability.
+ */
+
+/**
+ * Parses email addresses from a header value.
+ * Handles formats like:
+ * - "email@example.com"
+ * - "Name <email@example.com>"
+ * - Multiple addresses separated by commas
+ *
+ * @param headerValue - The raw header value (e.g., From, To, CC)
+ * @returns Array of extracted email addresses
+ */
+export function parseEmailAddresses(headerValue: string): string[] {
+    if (!headerValue) return [];
+
+    const emails: string[] = [];
+    const parts = headerValue.split(',');
+
+    for (const part of parts) {
+        const trimmed = part.trim();
+        // Extract email from "Name <email>" format
+        const match = trimmed.match(/<([^>]+)>/);
+        if (match) {
+            emails.push(match[1].trim());
+        } else if (trimmed.includes('@')) {
+            emails.push(trimmed);
+        }
+    }
+
+    return emails;
+}
+
+/**
+ * Filters out the authenticated user's email from a list of emails.
+ * Case-insensitive comparison.
+ *
+ * @param emails - Array of email addresses to filter
+ * @param myEmail - The authenticated user's email address
+ * @returns Filtered array excluding the user's email
+ */
+export function filterOutEmail(emails: string[], myEmail: string): string[] {
+    const myEmailLower = myEmail.toLowerCase();
+    return emails.filter(email => email.toLowerCase() !== myEmailLower);
+}
+
+/**
+ * Adds "Re: " prefix to a subject if not already present.
+ * Case-insensitive check for existing prefix.
+ *
+ * @param subject - The original email subject
+ * @returns Subject with "Re: " prefix
+ */
+export function addRePrefix(subject: string): string {
+    if (subject.toLowerCase().startsWith('re:')) {
+        return subject;
+    }
+    return `Re: ${subject}`;
+}
+
+/**
+ * Builds the References header for a reply email.
+ * Combines original References with original Message-ID.
+ *
+ * @param originalReferences - The References header from the original email
+ * @param originalMessageId - The Message-ID of the original email
+ * @returns Combined References header value
+ */
+export function buildReferencesHeader(originalReferences: string, originalMessageId: string): string {
+    if (!originalMessageId) {
+        return originalReferences;
+    }
+    return originalReferences ? `${originalReferences} ${originalMessageId}` : originalMessageId;
+}
+
+/**
+ * Builds recipient lists for a reply-all email.
+ *
+ * Rules:
+ * - TO: original From (sender of the email)
+ * - CC: original To + original CC (excluding the authenticated user)
+ *
+ * @param originalFrom - From header value
+ * @param originalTo - To header value
+ * @param originalCc - CC header value
+ * @param myEmail - The authenticated user's email address
+ * @returns Object with 'to' and 'cc' arrays
+ */
+export function buildReplyAllRecipients(
+    originalFrom: string,
+    originalTo: string,
+    originalCc: string,
+    myEmail: string
+): { to: string[]; cc: string[] } {
+    const fromEmails = parseEmailAddresses(originalFrom);
+    const toEmails = parseEmailAddresses(originalTo);
+    const ccEmails = parseEmailAddresses(originalCc);
+
+    // TO recipients: original From (the person who sent the email), excluding myself
+    const replyTo = filterOutEmail(fromEmails, myEmail);
+
+    // CC recipients: everyone else who was on To and CC, excluding myself
+    const replyCc = filterOutEmail([...toEmails, ...ccEmails], myEmail);
+
+    return {
+        to: replyTo,
+        cc: replyCc
+    };
+}


### PR DESCRIPTION
## Summary

- Adds a new `reply_all` tool that simplifies replying to all recipients on an email thread
- Automatically fetches the original email headers (From, To, CC) to build the recipient list
- Excludes the authenticated user's email from recipients
- Sets proper threading headers (In-Reply-To, References, threadId) for correct thread grouping

## Motivation

Currently, users must manually specify all recipients when replying to an email. This is tedious and error-prone, especially for emails with multiple recipients. The `reply_all` tool automates this by:

1. Taking only a `messageId` as required input (plus the reply body)
2. Fetching the original email to extract headers
3. Building the recipient list: original sender -> To, original To/CC -> CC
4. Automatically excluding the authenticated user from recipients
5. Adding "Re:" prefix to subject if not present
6. Setting proper threading headers

Includes 32 unit tests for the recipient-building logic.

Originally submitted as GongRzhe/Gmail-MCP-Server#76, resubmitted here per maintainer invitation.
