### PR TITLE
Fix listFilters returning empty array - wrong response property name

### DIFF
--- a/src/filter-manager.ts
+++ b/src/filter-manager.ts
@@ -67,7 +67,7 @@ export async function listFilters(gmail: any) {
             userId: 'me',
         });
 
-        const filters = response.data.filters || [];
+        const filters = response.data.filter || [];
         
         return {
             filters,


### PR DESCRIPTION
## Summary
- Fixed `listFilters` returning empty array — the code was reading `response.data.filters` but the Gmail API returns `response.data.filter`

## Details
One-line fix in `src/filter-manager.ts`: changed `response.data.filters` to `response.data.filter` to match the actual Gmail API response shape.

This is a resubmission of [GongRzhe/Gmail-MCP-Server#92](https://github.com/GongRzhe/Gmail-MCP-Server/pull/92).

## Test plan
- Call `list_filters` tool and verify it returns actual filters instead of an empty array

🤖 Generated with [Claude Code](https://claude.com/claude-code)