### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -134,11 +134,20 @@ export const ReplyAllSchema = z.object({
 });
 
 // Tool definition type
+export interface ToolAnnotations {
+  title: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
   schema: z.ZodType<any>;
   scopes: string[]; // Any of these scopes grants access
+  annotations: ToolAnnotations;
 }
 
 // Tool registry with scope requirements
@@ -149,18 +158,21 @@ export const toolDefinitions: ToolDefinition[] = [
     description: "Retrieves the content of a specific email",
     schema: ReadEmailSchema,
     scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Read Email", readOnlyHint: true },
   },
   {
     name: "search_emails",
     description: "Searches for emails using Gmail search syntax",
     schema: SearchEmailsSchema,
     scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Search Emails", readOnlyHint: true },
   },
   {
     name: "download_attachment",
     description: "Downloads an email attachment to a specified location",
     schema: DownloadAttachmentSchema,
     scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Download Attachment", readOnlyHint: true },
   },
 
   // Email write operations
@@ -169,36 +181,42 @@ export const toolDefinitions: ToolDefinition[] = [
     description: "Sends a new email",
     schema: SendEmailSchema,
     scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+    annotations: { title: "Send Email", destructiveHint: false },
   },
   {
     name: "draft_email",
     description: "Draft a new email",
     schema: SendEmailSchema,
     scopes: ["gmail.modify", "gmail.compose"],
+    annotations: { title: "Draft Email", destructiveHint: false },
   },
   {
     name: "modify_email",
     description: "Modifies email labels (move to different folders)",
     schema: ModifyEmailSchema,
     scopes: ["gmail.modify"],
+    annotations: { title: "Modify Email", destructiveHint: true, idempotentHint: true },
   },
   {
     name: "delete_email",
     description: "Permanently deletes an email",
     schema: DeleteEmailSchema,
     scopes: ["gmail.modify"],
+    annotations: { title: "Delete Email", destructiveHint: true },
   },
   {
     name: "batch_modify_emails",
     description: "Modifies labels for multiple emails in batches",
     schema: BatchModifyEmailsSchema,
     scopes: ["gmail.modify"],
+    annotations: { title: "Batch Modify Emails", destructiveHint: true, idempotentHint: true },
   },
   {
     name: "batch_delete_emails",
     description: "Permanently deletes multiple emails in batches",
     schema: BatchDeleteEmailsSchema,
     scopes: ["gmail.modify"],
+    annotations: { title: "Batch Delete Emails", destructiveHint: true },
   },
 
   // Label operations
@@ -207,30 +225,35 @@ export const toolDefinitions: ToolDefinition[] = [
     description: "Retrieves all available Gmail labels",
     schema: ListEmailLabelsSchema,
     scopes: ["gmail.readonly", "gmail.modify", "gmail.labels"],
+    annotations: { title: "List Email Labels", readOnlyHint: true },
   },
   {
     name: "create_label",
     description: "Creates a new Gmail label",
     schema: CreateLabelSchema,
     scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Create Label", destructiveHint: false },
   },
   {
     name: "update_label",
     description: "Updates an existing Gmail label",
     schema: UpdateLabelSchema,
     scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Update Label", destructiveHint: true, idempotentHint: true },
   },
   {
     name: "delete_label",
     description: "Deletes a Gmail label",
     schema: DeleteLabelSchema,
     scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Delete Label", destructiveHint: true },
   },
   {
     name: "get_or_create_label",
     description: "Gets an existing label by name or creates it if it doesn't exist",
     schema: GetOrCreateLabelSchema,
     scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Get or Create Label", destructiveHint: false, idempotentHint: true },
   },
 
   // Filter operations (require settings scope)
@@ -239,30 +262,35 @@ export const toolDefinitions: ToolDefinition[] = [
     description: "Retrieves all Gmail filters",
     schema: ListFiltersSchema,
     scopes: ["gmail.settings.basic"],
+    annotations: { title: "List Filters", readOnlyHint: true },
   },
   {
     name: "get_filter",
     description: "Gets details of a specific Gmail filter",
     schema: GetFilterSchema,
     scopes: ["gmail.settings.basic"],
+    annotations: { title: "Get Filter", readOnlyHint: true },
   },
   {
     name: "create_filter",
     description: "Creates a new Gmail filter with custom criteria and actions",
     schema: CreateFilterSchema,
     scopes: ["gmail.settings.basic"],
+    annotations: { title: "Create Filter", destructiveHint: false },
   },
   {
     name: "delete_filter",
     description: "Deletes a Gmail filter",
     schema: DeleteFilterSchema,
     scopes: ["gmail.settings.basic"],
+    annotations: { title: "Delete Filter", destructiveHint: true },
   },
   {
     name: "create_filter_from_template",
     description: "Creates a filter using a pre-defined template for common scenarios",
     schema: CreateFilterFromTemplateSchema,
     scopes: ["gmail.settings.basic"],
+    annotations: { title: "Create Filter from Template", destructiveHint: false },
   },
 
   // Reply-all operation
@@ -271,6 +299,7 @@ export const toolDefinitions: ToolDefinition[] = [
     description: "Replies to all recipients of an email. Automatically fetches the original email to build the recipient list (To, CC) and sets proper threading headers.",
     schema: ReplyAllSchema,
     scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+    annotations: { title: "Reply All", destructiveHint: false },
   },
 ];
 
@@ -280,6 +309,7 @@ export function toMcpTools(tools: ToolDefinition[]) {
     name: tool.name,
     description: tool.description,
     inputSchema: zodToJsonSchema(tool.schema),
+    annotations: tool.annotations,
   }));
 }
 


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) to all 20 tools to help MCP clients understand tool behavior and make safer decisions about tool execution.

> Originally submitted as [GongRzhe/Gmail-MCP-Server#65](https://github.com/GongRzhe/Gmail-MCP-Server/pull/65), resubmitted here per @ArtyMcLabin's suggestion since the upstream repo appears inactive.

## Changes

Single file change (`src/tools.ts`, +30 lines):
- Added `ToolAnnotations` interface and `annotations` field to `ToolDefinition`
- Updated `toMcpTools()` to include annotations in `tools/list` response

### READ Operations (6 tools) — `readOnlyHint: true`
| Tool | Title |
|------|-------|
| `read_email` | Read Email |
| `search_emails` | Search Emails |
| `download_attachment` | Download Attachment |
| `list_email_labels` | List Email Labels |
| `list_filters` | List Filters |
| `get_filter` | Get Filter |

### WRITE Operations (7 tools) — `destructiveHint: false` (additive)
| Tool | Title |
|------|-------|
| `send_email` | Send Email |
| `draft_email` | Draft Email |
| `create_label` | Create Label |
| `get_or_create_label` | Get or Create Label |
| `create_filter` | Create Filter |
| `create_filter_from_template` | Create Filter from Template |
| `reply_all` | Reply All |

### MODIFY Operations (3 tools) — `destructiveHint: true`, `idempotentHint: true`
| Tool | Title |
|------|-------|
| `modify_email` | Modify Email |
| `batch_modify_emails` | Batch Modify Emails |
| `update_label` | Update Label |

### DELETE Operations (4 tools) — `destructiveHint: true`
| Tool | Title |
|------|-------|
| `delete_email` | Delete Email |
| `batch_delete_emails` | Batch Delete Emails |
| `delete_label` | Delete Label |
| `delete_filter` | Delete Filter |

## Why This Matters

Tool annotations are part of the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#annotations) that enable:
- MCP clients to auto-approve safe (read-only) operations without user confirmation
- Destructive tools to trigger confirmation prompts
- Idempotent tools to be safely retried on failure
- Human-readable titles for better tool display

## Testing

- [x] `npm run build` — compiles with no errors
- [x] `npm test` — all 38 tests pass
- [x] Verified `toMcpTools()` output includes annotations with correct JSON serialization
- [x] `undefined` annotation fields correctly omitted from JSON output
- [x] No functional changes to tool behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)