### PR TITLE
feat: add --tool-prefix CLI flag for multi-instance use

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,29 @@ node dist/index.js auth --scopes=gmail.modify,gmail.settings.basic
 
 This enables all 23 tools including sending emails, managing labels, creating filters, reply-all, thread operations, phishing reports, and batch operations.
 
+### Running multiple instances (tool-name prefix)
+
+Some MCP clients dedupe tool entries by their base name across servers, which makes it impossible to run two instances of this server side-by-side (e.g. one for a personal account and one for a shared inbox) — only one instance's tools surface, even though both servers report as connected.
+
+The server accepts an optional `--tool-prefix=<value>` CLI flag (or `GMAIL_MCP_TOOL_PREFIX` env var) that is prepended to every tool name at registration. Default is empty (fully backward-compatible).
+
+Example: register two instances with distinct prefixes in Claude Code:
+
+```bash
+# Personal account
+claude mcp add gmail-personal -s user \
+  -e GMAIL_CREDENTIALS_PATH=$HOME/.gmail-mcp/credentials-personal.json \
+  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=personal_
+
+# Shared inbox
+claude mcp add gmail-info -s user \
+  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=info_
+```
+
+Tools then surface as `mcp__gmail-personal__personal_search_emails`, `mcp__gmail-info__info_search_emails`, etc. — distinct at every layer. The dispatch handler strips the prefix and looks up the resolved name via `getToolByName`; only strips when the result is a known tool (so a prefix value that overlaps a real tool name cannot cause silent mis-dispatch).
+
+The `auth` subcommand runs before the server starts and is unaffected — invoke it without `--tool-prefix`.
+
 ## Available Tools
 
 The server provides the following tools that can be used through Claude Desktop:

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,26 @@ const CONFIG_DIR = path.join(os.homedir(), '.gmail-mcp');
 const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, 'gcp-oauth.keys.json');
 const CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, 'credentials.json');
 
+// Optional tool-name prefix — lets multiple instances of this server run side-by-side
+// without their tool names colliding in clients that disambiguate by base name.
+// Precedence: --tool-prefix=<value> / --tool-prefix <value> CLI flag, then
+// GMAIL_MCP_TOOL_PREFIX env var, then empty (no prefix → backward compatible).
+// Does not affect the `auth` subcommand, which is detected via process.argv[2] === 'auth'
+// and exits before the server starts — run `auth` without --tool-prefix.
+const TOOL_PREFIX = (() => {
+    const args = process.argv.slice(2);
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i] ?? '';
+        if (arg.startsWith('--tool-prefix=')) {
+            return arg.slice('--tool-prefix='.length);
+        }
+        if (arg === '--tool-prefix' && i + 1 < args.length) {
+            return args[i + 1] ?? '';
+        }
+    }
+    return process.env.GMAIL_MCP_TOOL_PREFIX || '';
+})();
+
 // Type definitions for Gmail API responses
 interface GmailMessagePart {
     partId?: string;
@@ -306,11 +326,22 @@ async function main() {
         const availableTools = toolDefinitions.filter(tool =>
             hasScope(authorizedScopes, tool.scopes)
         );
-        return { tools: toMcpTools(availableTools) };
+        const mcpTools = toMcpTools(availableTools);
+        // Apply optional TOOL_PREFIX so multiple server instances can coexist
+        // in clients that dedupe tool entries by base name.
+        return { tools: mcpTools.map(t => ({ ...t, name: TOOL_PREFIX + t.name })) };
     });
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
-        const { name, arguments: args } = request.params;
+        const { name: rawName, arguments: args } = request.params;
+
+        // Strip TOOL_PREFIX only if the result is a known base tool name.
+        // Guards against accidental over-stripping when the prefix overlaps a tool name's start
+        // (e.g. prefix="send_" + rawName="send_email" → "email", which is not a tool).
+        const stripped = TOOL_PREFIX && rawName.startsWith(TOOL_PREFIX)
+            ? rawName.slice(TOOL_PREFIX.length)
+            : rawName;
+        const name = getToolByName(stripped) ? stripped : rawName;
 
         // Verify the tool is authorized for the current scopes
         // This guards against direct tool calls that bypass ListTools


### PR DESCRIPTION
## Summary

Adds an optional `--tool-prefix=<value>` CLI flag (with `GMAIL_MCP_TOOL_PREFIX` env var fallback) so multiple instances of this server can coexist in MCP clients that dedupe tool entries by base name.

## Why

Today, running two instances of this server (e.g. one for a personal Gmail and one for a shared inbox) fails in some clients. Both instances show as connected, but only one's tools surface — the other is silently shadowed because the tool *base names* (`search_emails`, `read_email`, etc.) collide across servers.

Observed in Claude Code: registering `gmail-info` and `gmail-personal` as two separate stdio servers with distinct credential paths surfaces only `mcp__gmail-info__*` tools; `mcp__gmail-personal__*` tools never become callable despite the server reporting Connected. This is a real blocker for multi-account workflows.

## How

- `--tool-prefix=<value>` or `--tool-prefix <value>` parsed from `process.argv` once at module init (IIFE)
- `GMAIL_MCP_TOOL_PREFIX` env var as fallback (idiomatic for MCP server config)
- `ListToolsRequestSchema` handler `.map()`s the existing `toMcpTools()` output through `TOOL_PREFIX + name`
- `CallToolRequestSchema` handler strips the prefix and resolves via the existing `getToolByName()` — only strips when the result is a known tool, so a prefix value that happens to overlap a real tool name (e.g. \`--tool-prefix=send_\`) cannot cause silent mis-dispatch
- Auth + scope check at the original dispatch site is untouched

## Backward compatibility

Default prefix is empty. Users who don't pass the flag see zero behavior change. The \`auth\` subcommand (detected via \`process.argv[2] === 'auth'\`) runs before the server starts and is unaffected.

## Example usage (Claude Code, two-instance)

\`\`\`bash
# Personal account
claude mcp add gmail-personal -s user \
  -e GMAIL_CREDENTIALS_PATH=\$HOME/.gmail-mcp/credentials-personal.json \
  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=personal_

# Shared inbox
claude mcp add gmail-info -s user \
  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=info_
\`\`\`

Tools surface as \`mcp__gmail-personal__personal_search_emails\` and \`mcp__gmail-info__info_search_emails\` — distinct at every layer.

## Test plan

- [x] \`npm run build\` clean under existing \`strict: true\`
- [x] \`npm test\` — all 112 existing tests pass
- [x] Stdio JSON-RPC \`tools/list\` with \`--tool-prefix=arty_\` → all tool names returned with \`arty_\` prefix
- [x] Stdio JSON-RPC \`tools/list\` with no flag → tool names unchanged (backward-compat)
- [x] Live-tested in Claude Code with two MCP server instances (\`info_\`, \`personal_\`); both toolsets surface and route to the correct Gmail account
- [x] \`auth\` subcommand unaffected (still detected via \`process.argv[2]\`)

## Threat-model note

Patch is purely additive: no new network I/O, no new filesystem writes, no new credential reads. Per the repo's CLAUDE.md (local stdio MCP threat model: focus on credential leaks / network exposure / supply chain), this introduces no new surface.

## Files changed

- \`src/index.ts\`: +27 / -3 (constant + ListTools map + CallTool strip)
- \`README.md\`: +24 / 0 (new "Running multiple instances" subsection under "Claude Code CLI Configuration")

🤖 Generated with [Claude Code](https://claude.com/claude-code)