### PR TITLE
fix(auth): persist refresh_token so OAuth survives across restarts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,25 @@ async function loadCredentials() {
             if (credentials.scopes) {
                 authorizedScopes = credentials.scopes;
             }
+
+            // Persist refreshed tokens so refresh_token survives access_token rotation.
+            // Without this, google-auth-library's silent refresh updates only the
+            // in-memory client; on next process start we'd re-read a stale token.
+            oauth2Client.on('tokens', (newTokens) => {
+                try {
+                    const onDisk = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
+                    const currentTokens = onDisk.tokens || onDisk;
+                    const mergedTokens = newTokens.refresh_token
+                        ? { ...currentTokens, ...newTokens }
+                        : { ...currentTokens, access_token: newTokens.access_token, expiry_date: newTokens.expiry_date };
+                    const updated = onDisk.tokens
+                        ? { ...onDisk, tokens: mergedTokens }
+                        : mergedTokens;
+                    fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(updated, null, 2), { mode: 0o600 });
+                } catch (err) {
+                    console.error('Failed to persist refreshed tokens:', err);
+                }
+            });
         }
     } catch (error) {
         console.error('Error loading credentials:', error);
@@ -209,6 +228,7 @@ async function authenticate(scopes: string[]) {
     return new Promise<void>((resolve, reject) => {
         const authUrl = oauth2Client.generateAuthUrl({
             access_type: 'offline',
+            prompt: 'consent',
             scope: scopeUrls,
         });
 


### PR DESCRIPTION
## Problem

The server loses authentication roughly every hour and requires a manual re-auth. The root cause is that it never reliably retains a `refresh_token`, so once the ~1-hour `access_token` expires there is nothing to refresh from. This matches upstream GongRzhe/Gmail-MCP-Server [Issue #50](https://github.com/GongRzhe/Gmail-MCP-Server/issues/50).

There are two independent contributing bugs:

1. **`generateAuthUrl()` omits `prompt: 'consent'`.** With only `access_type: 'offline'`, Google returns a `refresh_token` *solely* on the first consent for a given (user, OAuth client) pair. Every subsequent auth flow is treated as silent re-authentication and returns an `access_token` only — and the auth handler then overwrites `credentials.json` with that refresh-token-less response, discarding any prior `refresh_token`.

2. **No `on('tokens')` listener.** `google-auth-library` rotates the `access_token` silently in memory, but nothing persists the rotated token to disk. On the next process start the server re-reads a now-stale token.

## Fix

1. Add `prompt: 'consent'` to `generateAuthUrl()` so Google always re-prompts and therefore always returns a `refresh_token`.
2. Add an `oauth2Client.on('tokens', …)` listener that merges rotated tokens back into `credentials.json`, **preserving** the `refresh_token` and the existing `{ tokens, scopes }` credential wrapper, written with mode `0600`.

Together these make the credential durable across both `access_token` expiry and process restarts.

## Testing

- `npm run build` (tsc) compiles clean on Node 25.
- After re-auth, `credentials.json` is written with a populated `tokens.refresh_token`, and the MCP server connects and lists labels end-to-end.
- The branch is rebased on the current `main` tip; the change is isolated to `src/index.ts` (+20 lines) and does not touch the recently-added draft-lifecycle / phishing tools.

---
*This PR was researched and written by an AI assistant (Claude) on behalf of Brent Baccala (cosine@freesoft.org), based on source analysis of `src/index.ts` and a reproduced ~hourly auth-drop on this fork. The fix mirrors the root-cause analysis in upstream Issue #50.*