### PR TITLE
Derive OAuth callback port and path from the callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ npm run build
    > - Both Desktop app and Web application credentials are supported
    > - For Web application credentials, make sure to add `http://localhost:3000/oauth2callback` to your authorized redirect URIs
 
+   **Custom callback URL / port:** By default the local OAuth server listens on port `3000` at `/oauth2callback`. If port 3000 is unavailable, or you need a different redirect URI, pass a full callback URL as an argument. The listener automatically binds to the port and path from that URL:
+
+   ```bash
+   node dist/index.js auth http://localhost:8080/oauth2callback
+   ```
+
+   The URL you pass must exactly match one of the authorized redirect URIs registered in the Google Cloud Console.
+
 3. Configure in Claude Desktop:
 
 ```json
@@ -970,8 +978,9 @@ The server includes efficient batch processing capabilities:
    - For web applications, verify the redirect URI is correctly configured
 
 3. **Port Already in Use**
-   - If port 3000 is already in use, please free it up before running authentication
-   - You can find and stop the process using that port
+   - By default authentication uses port 3000; either free it up before running authentication, or run on a different port by passing a custom callback URL (e.g. `node dist/index.js auth http://localhost:8080/oauth2callback`)
+   - If freeing port 3000, you can find and stop the process using that port
+   - A custom callback URL must match one of the authorized redirect URIs registered in the Google Cloud Console
 
 4. **Batch Operation Failures**
    - If batch operations fail, they automatically retry individual items

--- a/llms-install.md
+++ b/llms-install.md
@@ -41,6 +41,12 @@ This guide will help you install and configure the Gmail AutoAuth MCP server for
    - Launch browser for Google authentication
    - Save credentials as ~/.gmail-mcp/credentials.json
 
+   By default the local OAuth server listens on port 3000 at /oauth2callback. To use a different port or path (for example if port 3000 is unavailable), pass a full callback URL; the listener binds to the port and path from that URL:
+   ```bash
+   npx @gongrzhe/server-gmail-autoauth-mcp auth http://localhost:8080/oauth2callback
+   ```
+   The URL must exactly match one of the authorized redirect URIs registered in the Google Cloud Console.
+
 4. Configure Claude Desktop by adding the MCP server configuration:
    ```json
    {
@@ -67,7 +73,7 @@ If you encounter any issues during installation:
 2. Authentication Errors:
    - Confirm Gmail API is enabled
    - For web applications, verify redirect URI configuration
-   - Check port 3000 is available during authentication
+   - Check port 3000 is available during authentication, or pass a custom callback URL to use a different port (e.g. `auth http://localhost:8080/oauth2callback`)
 
 3. Configuration Issues:
    - Verify ~/.gmail-mcp directory exists and has correct permissions

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ interface EmailContent {
 // OAuth2 configuration
 let oauth2Client: OAuth2Client;
 let authorizedScopes: string[] = DEFAULT_SCOPES;
+let callbackUrl: URL;
 
 /**
  * Recursively extract email body content from MIME message parts
@@ -168,6 +169,7 @@ async function loadCredentials() {
             arg.startsWith('http://') || arg.startsWith('https://')
         );
         const callback = callbackArg || "http://localhost:3000/oauth2callback";
+        callbackUrl = new URL(callback);
 
         oauth2Client = new OAuth2Client(
             keys.client_id,
@@ -201,7 +203,8 @@ async function loadCredentials() {
 
 async function authenticate(scopes: string[]) {
     const server = http.createServer();
-    server.listen(3000, '127.0.0.1');
+    const port = Number(callbackUrl.port) || 3000;
+    server.listen(port, '127.0.0.1');
 
     // Convert shorthand scope names (e.g., "gmail.readonly") to full Google API URLs
     const scopeUrls = scopeNamesToUrls(scopes);
@@ -217,9 +220,9 @@ async function authenticate(scopes: string[]) {
         open(authUrl);
 
         server.on('request', async (req, res) => {
-            if (!req.url?.startsWith('/oauth2callback')) return;
+            if (!req.url?.startsWith(callbackUrl.pathname)) return;
 
-            const url = new URL(req.url, 'http://localhost:3000');
+            const url = new URL(req.url, callbackUrl.origin);
             const code = url.searchParams.get('code');
 
             if (!code) {


### PR DESCRIPTION
# What

The auth command already accepts a custom OAuth callback URL as a positional argument, but the local HTTP server that catches the redirect hard-codes port 3000 and the /oauth2callback path independently of that URL. So passing a custom callback is accepted without error, yet the flow hangs — Google redirects to a port/path where nothing is listening.

This PR makes the callback URL the single source of truth: the listener derives its port, origin, and path from it. Fixes #40.

# Why

- Fixes a latent bug — the existing callback argument silently doesn't work for any non-3000 port or non-/oauth2callback path.
- Unblocks port 3000 conflicts — users can now run the flow on another port instead of having to free 3000.

# Changes

src/index.ts:
- Parse the resolved callback into a URL once and reuse it.
- `server.listen(...)` now uses `Number(callbackUrl.port) || 3000`.
- The request-URL parsing base uses callbackUrl.origin instead of the hard-coded http://localhost:3000.
- The redirect path check uses callbackUrl.pathname instead of the literal /oauth2callback.

Docs (README.md, llms-install.md):
- Document the custom callback URL usage and note it must match an authorized redirect URI in the Google Cloud Console.

# Backward compatibility

Fully backward compatible. With no argument, the default remains http://localhost:3000/oauth2callback — same port, same path, same behavior as before.

# How to test

```
# Default (unchanged)
node dist/index.js auth

# Custom port/path — now actually works
node dist/index.js auth http://localhost:8080/oauth2callback
```

(Register the matching redirect URI in the Google Cloud Console first.)