### PR TITLE
fix(scopes): name missing scope + re-auth cmd on gated tool calls; docs for #38 & #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ dist/
 .DS_Store
 Thumbs.db
 
+# Local tool/plugin artifacts (RuVector memory graph from ruflo Claude Code plugins)
+ruvector.db
+agentdb.rvf
+agentdb.rvf.lock
+
 # Project specific
 mcp-config.json
 gcp-oauth.keys.json

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ There's a downstream fork that took this in the **maximalist** direction. I'm no
 - **Draft lifecycle tools** - `send_draft`, `delete_draft`, `update_draft` close the orphan-draft gap: `send_draft` atomically sends an existing draft and removes it from Drafts (no ghost copy); `update_draft` mutates a draft in place preserving its ID (no draft pile-up across iteration loops); `delete_draft` discards an abandoned draft ([PR #30](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/30) by [@thisisambros](https://github.com/thisisambros))
 - **Tool annotations** - MCP spec annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) on all tools for safer LLM tool execution ([PR #14](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/14) by [@bryankthompson](https://github.com/bryankthompson))
 - **Download email tool** - `download_email` saves emails to disk in json/eml/txt/html formats without consuming LLM context ([PR #13](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/13) by [@icanhasjonas](https://github.com/icanhasjonas))
+- **Persistent OAuth refresh token** - auth now survives server restarts and access-token rotation: refreshed tokens are written back to the credentials file, and the consent prompt always requests a `refresh_token`, so you no longer have to re-authenticate periodically ([PR #35](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/35) by [@BrentBaccala](https://github.com/BrentBaccala))
 
 All features are production-tested in daily use.
 
@@ -285,6 +286,8 @@ The server automatically filters available tools based on your authorized scopes
 ### Re-authenticating
 
 To change your scopes, simply run the auth command again with different scopes. This will replace your existing credentials.
+
+Once authenticated, credentials persist across restarts: the server writes refreshed tokens back to the credentials file as the access token rotates, and initial auth always requests a `refresh_token`, so you should not need to re-authenticate under normal use. Re-run `auth` only when you want to **change scopes** (for example adding `gmail.full` for permanent delete — see [OAuth Scopes](#oauth-scopes)) or if you revoked the app's access in your Google account and hit an `invalid_grant` error.
 
 ## Claude Code CLI Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,11 +368,28 @@ async function main() {
         // Verify the tool is authorized for the current scopes
         // This guards against direct tool calls that bypass ListTools
         const toolDef = getToolByName(name);
-        if (!toolDef || !hasScope(authorizedScopes, toolDef.scopes)) {
+        if (!toolDef) {
             return {
                 content: [{
                     type: "text",
                     text: `Error: Tool "${name}" is not available. You may need to re-authenticate with additional scopes.`,
+                }],
+            };
+        }
+        if (!hasScope(authorizedScopes, toolDef.scopes)) {
+            // Name the exact missing scope and the re-auth command so the user
+            // isn't left guessing (e.g. delete_email needs gmail.full, which the
+            // default gmail.modify does not cover — see issue #38).
+            const required = toolDef.scopes.join(" or ");
+            const suggested = Array.from(
+                new Set([...toolDef.scopes, "gmail.settings.basic"])
+            ).join(",");
+            return {
+                content: [{
+                    type: "text",
+                    text: `Error: Tool "${name}" requires the ${required} scope. `
+                        + `Your current authorization grants: ${authorizedScopes.join(", ") || "(none)"}. `
+                        + `Re-authenticate to add it, e.g.:\n  node dist/index.js auth --scopes=${suggested}`,
                 }],
             };
         }


### PR DESCRIPTION
## Summary

Two fixes plus a housekeeping change.

### #38 — `delete_email` "Insufficient Permission" with no guidance
The scope-gating, tool metadata (`delete_email`/`batch_delete_emails` require `gmail.full`), and README already existed on `experimental`. The remaining gap was the **runtime error**: calling a gated tool returned a bare *"Tool X is not available. You may need to re-authenticate with additional scopes."* — the user never learns *which* scope.

Now the error names the exact required scope, shows the current authorization, and prints the fix command:

```
Error: Tool "delete_email" requires the gmail.full scope. Your current authorization grants: gmail.modify, gmail.settings.basic. Re-authenticate to add it, e.g.:
  node dist/index.js auth --scopes=gmail.full,gmail.settings.basic
```

(`getToolByName` miss and scope miss are now separate branches so each returns the appropriate message.)

### #42 — README out of date (commit 29474ba / PR #35)
Documented PR #35's **persistent OAuth refresh-token** behavior: added a "What this fork adds" entry and expanded the *Re-authenticating* section to explain tokens now survive restarts and you only re-auth to change scopes or after revoking access. Closes the CI README-gap flag.

### Housekeeping
`.gitignore`: ignore local `ruvector.db` / `agentdb.rvf` (RuVector artifacts dropped by the ruflo Claude Code plugins) so they can't be accidentally committed.

## Testing
- `npm run build` — clean (tsc)
- `npx vitest run` — **153/153 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)