### PR TITLE
fix: MIME encoding, reply-all threading, error contract and auth robustness

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -203,13 +204,22 @@ async function loadCredentials() {
             // Legacy structure (pre-v1.2.0):
             //   { access_token, refresh_token, ... }
             //
-            // We support both formats for backwards compatibility. Users with legacy
-            // credentials will get DEFAULT_SCOPES (full access) until they re-authenticate.
+            // We support both formats for backwards compatibility. Legacy credentials
+            // carry no scope record, so we keep DEFAULT_SCOPES (gmail.modify +
+            // gmail.settings.basic) as an assumption — it is NOT full access, and it may
+            // not match what the stored token was actually granted. Tool exposure can
+            // therefore diverge from real token capability until re-authentication.
             const tokens = credentials.tokens || credentials;
             oauth2Client.setCredentials(tokens);
 
             if (credentials.scopes) {
                 authorizedScopes = credentials.scopes;
+            } else {
+                // stderr only: stdout is the MCP stdio protocol channel
+                console.error(
+                    `Warning: credentials file has no recorded scopes (legacy format). Assuming ${DEFAULT_SCOPES.join(', ')}; ` +
+                    'tool availability may not match the token\'s real permissions. Re-run `auth` to record actual scopes.'
+                );
             }
 
             // Persist refreshed tokens so refresh_token survives access_token rotation.
@@ -248,21 +258,32 @@ async function authenticate(scopes: string[]) {
     const port = callbackUrl.port
         ? Number(callbackUrl.port)
         : (callbackUrl.protocol === 'https:' ? 3000 : 80);
-    server.listen(port, '127.0.0.1');
 
     // Convert shorthand scope names (e.g., "gmail.readonly") to full Google API URLs
     const scopeUrls = scopeNamesToUrls(scopes);
 
-    return new Promise<void>((resolve, reject) => {
-        const authUrl = oauth2Client.generateAuthUrl({
-            access_type: 'offline',
-            prompt: 'consent',
-            scope: scopeUrls,
-        });
+    // Random state, echoed back by Google and compared here, so an authorization
+    // code injected by another local process is rejected instead of exchanged.
+    const state = crypto.randomBytes(32).toString('hex');
 
-        console.log('Requesting scopes:', scopes.join(', '));
-        console.log('Please visit this URL to authenticate:', authUrl);
-        open(authUrl);
+    return new Promise<void>((resolve, reject) => {
+        // Every exit path closes the listener exactly once. Without this, a bind
+        // failure (EADDRINUSE) or a failed token exchange left the promise pending
+        // and the listener open, so `auth` hung with no diagnostic.
+        let settled = false;
+        const finish = (error?: Error) => {
+            if (settled) return;
+            settled = true;
+            server.close();
+            if (error) reject(error); else resolve();
+        };
+
+        server.on('error', (err: NodeJS.ErrnoException) => {
+            finish(new Error(
+                `Failed to start the local auth listener on 127.0.0.1:${port} (${err.code || err.message}). ` +
+                'Free the port or pass a callback URL with a different port.'
+            ));
+        });
 
         server.on('request', async (req, res) => {
             if (!req.url?.startsWith(callbackUrl.pathname)) return;
@@ -270,10 +291,17 @@ async function authenticate(scopes: string[]) {
             const url = new URL(req.url, callbackUrl.origin);
             const code = url.searchParams.get('code');
 
+            if (url.searchParams.get('state') !== state) {
+                res.writeHead(400);
+                res.end('Invalid state parameter');
+                finish(new Error('OAuth state mismatch - authorization response rejected'));
+                return;
+            }
+
             if (!code) {
                 res.writeHead(400);
                 res.end('No code provided');
-                reject(new Error('No code provided'));
+                finish(new Error('No code provided'));
                 return;
             }
 
@@ -288,13 +316,25 @@ async function authenticate(scopes: string[]) {
                 res.writeHead(200);
                 res.end('Authentication successful! You can close this window.');
                 console.log('Credentials saved with scopes:', scopes.join(', '));
-                server.close();
-                resolve();
-            } catch (error) {
+                finish();
+            } catch (error: any) {
                 res.writeHead(500);
                 res.end('Authentication failed');
-                reject(error);
+                finish(error instanceof Error ? error : new Error(String(error)));
             }
+        });
+
+        server.listen(port, '127.0.0.1', () => {
+            const authUrl = oauth2Client.generateAuthUrl({
+                access_type: 'offline',
+                prompt: 'consent',
+                scope: scopeUrls,
+                state,
+            });
+
+            console.log('Requesting scopes:', scopes.join(', '));
+            console.log('Please visit this URL to authenticate:', authUrl);
+            open(authUrl);
         });
     });
 }
@@ -376,6 +416,7 @@ async function main() {
         const toolDef = getToolByName(name);
         if (!toolDef || !hasScope(authorizedScopes, toolDef.scopes)) {
             return {
+                isError: true,
                 content: [{
                     type: "text",
                     text: `Error: Tool "${name}" is not available. You may need to re-authenticate with additional scopes.`,
@@ -735,6 +776,7 @@ async function main() {
                         };
                     } catch (error: any) {
                         return {
+                            isError: true,
                             content: [
                                 {
                                     type: "text",
@@ -1109,18 +1151,18 @@ async function main() {
 
                 case "get_or_create_label": {
                     const validatedArgs = GetOrCreateLabelSchema.parse(args);
-                    const result = await getOrCreateLabel(gmail, validatedArgs.name, {
+                    const { label, created } = await getOrCreateLabel(gmail, validatedArgs.name, {
                         messageListVisibility: validatedArgs.messageListVisibility,
                         labelListVisibility: validatedArgs.labelListVisibility,
                     });
 
-                    const action = result.type === 'user' && result.name === validatedArgs.name ? 'found existing' : 'created new';
-                    
+                    const action = created ? 'created new' : 'found existing';
+
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `Successfully ${action} label:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                                text: `Successfully ${action} label:\nID: ${label.id}\nName: ${label.name}\nType: ${label.type}`,
                             },
                         ],
                     };
@@ -1130,6 +1172,17 @@ async function main() {
                 // Filter management handlers
                 case "create_filter": {
                     const validatedArgs = CreateFilterSchema.parse(args);
+
+                    // Gmail API requires gmail.settings.sharing (not just settings.basic)
+                    // for filters carrying a forwarding action. Fail with a clear message
+                    // instead of letting the API return an opaque 403.
+                    if (validatedArgs.action.forward && !hasScope(authorizedScopes, ["gmail.settings.sharing"])) {
+                        throw new Error(
+                            'Filters with a forward action require the gmail.settings.sharing scope. ' +
+                            'Re-authenticate with --scopes=...,gmail.settings.sharing, or create the filter without "forward".'
+                        );
+                    }
+
                     const result = await createFilter(gmail, validatedArgs.criteria, validatedArgs.action);
 
                     // Format criteria for display
@@ -1351,6 +1404,7 @@ async function main() {
                         };
                     } catch (error: any) {
                         return {
+                            isError: true,
                             content: [
                                 {
                                     type: "text",
@@ -1680,6 +1734,11 @@ async function main() {
                         mimeType: validatedArgs.mimeType,
                         threadId: threadId,
                         inReplyTo: originalMessageId,
+                        // Passing inReplyTo skips handleEmailAction's thread-based header
+                        // resolution, so the chain built above must be passed explicitly.
+                        // Without it References collapses to the last Message-ID alone and
+                        // clients lose the conversation grouping on deep threads.
+                        references: references,
                         attachments: validatedArgs.attachments,
                         inlineImages: validatedArgs.inlineImages,
                     };
@@ -1732,7 +1791,10 @@ async function main() {
                     throw new Error(`Unknown tool: ${name}`);
             }
         } catch (error: any) {
+            // Tool failures must be flagged with isError; without it clients treat the
+            // "Error: ..." text as a successful result.
             return {
+                isError: true,
                 content: [
                     {
                         type: "text",

--- a/src/label-manager.ts
+++ b/src/label-manager.ts
@@ -181,22 +181,25 @@ export async function findLabelByName(gmail: any, labelName: string) {
  * @param gmail - Gmail API instance
  * @param labelName - Name of the label to create
  * @param options - Optional settings for the label
- * @returns The new or existing label
+ * @returns The label plus whether it was newly created (a created label is
+ *          indistinguishable from an existing one by shape alone — both are
+ *          type 'user' with the requested name — so the flag is the only
+ *          reliable way for callers to report what happened)
  */
 export async function getOrCreateLabel(gmail: any, labelName: string, options: {
     messageListVisibility?: string;
     labelListVisibility?: string;
-} = {}) {
+} = {}): Promise<{ label: GmailLabel; created: boolean }> {
     try {
         // First try to find an existing label
         const existingLabel = await findLabelByName(gmail, labelName);
-        
+
         if (existingLabel) {
-            return existingLabel;
+            return { label: existingLabel, created: false };
         }
-        
+
         // If not found, create a new one
-        return await createLabel(gmail, labelName, options);
+        return { label: await createLabel(gmail, labelName, options), created: true };
     } catch (error: any) {
         throw new Error(`Failed to get or create label: ${error.message}`);
     }

--- a/src/reply-all-helpers.test.ts
+++ b/src/reply-all-helpers.test.ts
@@ -195,6 +195,37 @@ describe('buildReplyAllRecipients', () => {
         expect(result.cc).toEqual(['recipient@example.com']);
     });
 
+    it('excludes the original sender from CC when they also appear in To', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'sender@example.com, other@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['sender@example.com']);
+        expect(result.cc).toEqual(['other@example.com']);
+    });
+
+    it('excludes the original sender from CC case-insensitively', () => {
+        const result = buildReplyAllRecipients(
+            'Sender <sender@example.com>',
+            'other@example.com',
+            'SENDER@EXAMPLE.COM',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com']);
+    });
+
+    it('removes duplicate CC addresses appearing in both To and CC', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'dup@example.com, other@example.com',
+            'Dup <dup@example.com>',
+            myEmail
+        );
+        expect(result.cc).toEqual(['dup@example.com', 'other@example.com']);
+    });
+
     it('is case insensitive when excluding authenticated user', () => {
         const result = buildReplyAllRecipients(
             'sender@example.com',

--- a/src/reply-all-helpers.ts
+++ b/src/reply-all-helpers.ts
@@ -47,6 +47,25 @@ export function filterOutEmail(emails: string[], myEmail: string): string[] {
 }
 
 /**
+ * Removes duplicate addresses, comparing case-insensitively and keeping the
+ * first occurrence's original casing.
+ *
+ * @param emails - Array of email addresses
+ * @returns Array without case-insensitive duplicates
+ */
+export function dedupeEmails(emails: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const email of emails) {
+        const key = email.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        result.push(email);
+    }
+    return result;
+}
+
+/**
  * Adds "Re: " prefix to a subject if not already present.
  * Case-insensitive check for existing prefix.
  *
@@ -80,7 +99,8 @@ export function buildReferencesHeader(originalReferences: string, originalMessag
  *
  * Rules:
  * - TO: original From (sender of the email)
- * - CC: original To + original CC (excluding the authenticated user)
+ * - CC: original To + original CC (excluding the authenticated user and anyone
+ *   already in TO; duplicates are removed case-insensitively)
  *
  * @param originalFrom - From header value
  * @param originalTo - To header value
@@ -99,10 +119,13 @@ export function buildReplyAllRecipients(
     const ccEmails = parseEmailAddresses(originalCc);
 
     // TO recipients: original From (the person who sent the email), excluding myself
-    const replyTo = filterOutEmail(fromEmails, myEmail);
+    const replyTo = dedupeEmails(filterOutEmail(fromEmails, myEmail));
 
-    // CC recipients: everyone else who was on To and CC, excluding myself
-    const replyCc = filterOutEmail([...toEmails, ...ccEmails], myEmail);
+    // CC recipients: everyone else who was on To and CC, excluding myself and
+    // anyone already in TO (a sender listed in To/CC would otherwise be addressed twice)
+    const replyToKeys = new Set(replyTo.map(email => email.toLowerCase()));
+    const replyCc = dedupeEmails(filterOutEmail([...toEmails, ...ccEmails], myEmail))
+        .filter(email => !replyToKeys.has(email.toLowerCase()));
 
     return {
         to: replyTo,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -142,7 +142,7 @@ export const CreateFilterSchema = z.object({
   action: z.object({
     addLabelIds: z.array(z.string()).optional().describe("Label IDs to add to matching emails"),
     removeLabelIds: z.array(z.string()).optional().describe("Label IDs to remove from matching emails"),
-    forward: z.string().optional().describe("Email address to forward matching emails to")
+    forward: z.string().optional().describe("Email address to forward matching emails to (requires the gmail.settings.sharing scope)")
   }).describe("Actions to perform on matching emails")
 }).describe("Creates a new Gmail filter");
 

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -164,6 +164,13 @@ describe('Source verification', () => {
         expect(source).toContain("validatedArgs.references = allMessageIds.join(' ')");
     });
 
+    it('reply_all forwards the built References chain to handleEmailAction', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+        const replyAllBlock = source.slice(source.indexOf('case "reply_all"'), source.indexOf('case "modify_thread"'));
+        expect(replyAllBlock).toContain('const references = buildReferencesHeader(');
+        expect(replyAllBlock).toContain('references: references');
+    });
+
     it('read_email returns Message-ID', () => {
         const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
         expect(source).toContain('message-id');

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -69,6 +69,87 @@ describe('Email threading headers', () => {
     });
 });
 
+describe('Body transfer encoding', () => {
+    // Extract the body of the last MIME part (headers end at the first blank line)
+    function getPartBody(raw: string): string {
+        const idx = raw.indexOf('\r\n\r\n');
+        return raw.slice(idx + 4);
+    }
+
+    it('keeps 7bit for ASCII-only plain bodies', () => {
+        const raw = createEmailMessage({
+            to: ['test@example.com'],
+            subject: 'ASCII',
+            body: 'Plain ASCII body',
+        });
+
+        expect(raw).toContain('Content-Transfer-Encoding: 7bit');
+        expect(getPartBody(raw)).toBe('Plain ASCII body');
+    });
+
+    it('uses base64 for non-ASCII plain bodies and round-trips the text', () => {
+        const body = 'こんにちは、これはテスト本文です。';
+        const raw = createEmailMessage({
+            to: ['test@example.com'],
+            subject: '日本語件名',
+            body,
+        });
+
+        expect(raw).toContain('Content-Transfer-Encoding: base64');
+        expect(raw).not.toContain('Content-Transfer-Encoding: 7bit');
+        const decoded = Buffer.from(getPartBody(raw).replace(/\r\n/g, ''), 'base64').toString('utf8');
+        expect(decoded).toBe(body);
+    });
+
+    it('uses base64 for non-ASCII HTML-only bodies', () => {
+        // Supplying htmlBody promotes the message to multipart/alternative, so the
+        // HTML-only branch is exercised with body alone.
+        const htmlBody = '<p>日本語の HTML 本文</p>';
+        const raw = createEmailMessage({
+            to: ['test@example.com'],
+            subject: 'HTML',
+            mimeType: 'text/html',
+            body: htmlBody,
+        });
+
+        expect(raw).toContain('Content-Type: text/html; charset=UTF-8');
+        expect(raw).toContain('Content-Transfer-Encoding: base64');
+        const decoded = Buffer.from(getPartBody(raw).replace(/\r\n/g, ''), 'base64').toString('utf8');
+        expect(decoded).toBe(htmlBody);
+    });
+
+    it('encodes each part independently in multipart/alternative', () => {
+        const body = '日本語テキスト';
+        const htmlBody = '<p>ASCII html</p>';
+        const raw = createEmailMessage({
+            to: ['test@example.com'],
+            subject: 'mixed',
+            mimeType: 'text/html',
+            body,
+            htmlBody,
+        });
+
+        expect(raw).toContain('Content-Transfer-Encoding: base64');
+        expect(raw).toContain('Content-Transfer-Encoding: 7bit');
+        expect(raw).toContain(Buffer.from(body, 'utf8').toString('base64'));
+        expect(raw).toContain(htmlBody);
+    });
+
+    it('wraps long base64 payloads at 76 characters', () => {
+        const raw = createEmailMessage({
+            to: ['test@example.com'],
+            subject: 'long',
+            body: 'あ'.repeat(500),
+        });
+
+        const lines = getPartBody(raw).split('\r\n').filter(Boolean);
+        expect(lines.length).toBeGreaterThan(1);
+        for (const line of lines) {
+            expect(line.length).toBeLessThanOrEqual(76);
+        }
+    });
+});
+
 describe('Source verification', () => {
     it('createEmailWithNodemailer uses references field with inReplyTo fallback', () => {
         const source = fs.readFileSync(path.join(srcDir, 'utl.ts'), 'utf-8');

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -36,6 +36,21 @@ function sanitizeHeaderValue(value: string): string {
     return value.replace(/[\r\n\0]/g, '');
 }
 
+/**
+ * RFC 2045 restricts 7bit to US-ASCII. Declaring a non-ASCII body as 7bit and
+ * emitting the raw bytes produces a non-conformant message that relaying MTAs
+ * and receiving clients may mangle. Bodies containing non-ASCII are switched to
+ * base64 and wrapped at 76 characters.
+ */
+function encodeBodyPart(body: string): { encoding: string; content: string } {
+    const text = body ?? '';
+    if (!/[^\x00-\x7F]/.test(text)) {
+        return { encoding: '7bit', content: text };
+    }
+    const base64 = Buffer.from(text, 'utf8').toString('base64');
+    return { encoding: 'base64', content: base64.match(/.{1,76}/g)?.join('\r\n') ?? '' };
+}
+
 export function createEmailMessage(validatedArgs: any): string {
     const encodedSubject = encodeEmailHeader(sanitizeHeaderValue(validatedArgs.subject));
     // Determine content type based on available content and explicit mimeType
@@ -86,35 +101,39 @@ export function createEmailMessage(validatedArgs: any): string {
         emailParts.push('');
         
         // Plain text part
+        const textPart = encodeBodyPart(validatedArgs.body);
         emailParts.push(`--${boundary}`);
         emailParts.push('Content-Type: text/plain; charset=UTF-8');
-        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push(`Content-Transfer-Encoding: ${textPart.encoding}`);
         emailParts.push('');
-        emailParts.push(validatedArgs.body);
+        emailParts.push(textPart.content);
         emailParts.push('');
-        
+
         // HTML part
+        const htmlPart = encodeBodyPart(validatedArgs.htmlBody || validatedArgs.body); // Use body as fallback
         emailParts.push(`--${boundary}`);
         emailParts.push('Content-Type: text/html; charset=UTF-8');
-        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push(`Content-Transfer-Encoding: ${htmlPart.encoding}`);
         emailParts.push('');
-        emailParts.push(validatedArgs.htmlBody || validatedArgs.body); // Use body as fallback
+        emailParts.push(htmlPart.content);
         emailParts.push('');
-        
+
         // Close the boundary
         emailParts.push(`--${boundary}--`);
     } else if (mimeType === 'text/html') {
         // HTML-only email
+        const htmlPart = encodeBodyPart(validatedArgs.htmlBody || validatedArgs.body);
         emailParts.push('Content-Type: text/html; charset=UTF-8');
-        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push(`Content-Transfer-Encoding: ${htmlPart.encoding}`);
         emailParts.push('');
-        emailParts.push(validatedArgs.htmlBody || validatedArgs.body);
+        emailParts.push(htmlPart.content);
     } else {
         // Plain text email (default)
+        const textPart = encodeBodyPart(validatedArgs.body);
         emailParts.push('Content-Type: text/plain; charset=UTF-8');
-        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push(`Content-Transfer-Encoding: ${textPart.encoding}`);
         emailParts.push('');
-        emailParts.push(validatedArgs.body);
+        emailParts.push(textPart.content);
     }
 
     return emailParts.join('\r\n');


### PR DESCRIPTION
Eight defects found while auditing `main` (v1.2.3). Each one is a place where the implementation contradicts the contract the code or schema advertises. All are behaviour-preserving for the paths that already worked.

## Fixes

| # | Area | Problem |
|---|---|---|
| 1 | `src/utl.ts` | Non-ASCII bodies emitted with `Content-Transfer-Encoding: 7bit` |
| 2 | `src/index.ts` | `reply_all` built a References chain and then discarded it |
| 3 | `src/index.ts` | Tool failures returned without `isError` |
| 4 | `src/index.ts` | OAuth listener could hang forever and leaked on failure; no `state` |
| 5 | `src/reply-all-helpers.ts` | Original sender kept in CC when also present in To; no de-duplication |
| 6 | `src/label-manager.ts` | `get_or_create_label` always reported "found existing" |
| 7 | `src/index.ts`, `src/tools.ts` | `create_filter` accepted `forward` without `gmail.settings.sharing` |
| 8 | `src/index.ts` | Legacy credentials documented as "full access" (they are not) |

### 1. Non-ASCII bodies are broken by 7bit encoding

`createEmailMessage()` declared `7bit` for every part while emitting the raw body. RFC 2045 limits `7bit` to US-ASCII, so any message containing non-ASCII text (CJK, accented Latin, emoji) was non-conformant and could be mangled in transit.

The defect was asymmetric and therefore easy to miss: mail with attachments or inline images goes through `createEmailWithNodemailer()`, which encodes correctly, so the *same* server produced a valid message or a broken one depending on whether a file happened to be attached. `send_email`, `draft_email` and `update_draft` without attachments hit the broken path.

Bodies are now scanned for non-ASCII and switched to base64 wrapped at 76 characters. ASCII-only bodies keep `7bit`, so existing output is byte-for-byte unchanged. Parts of a `multipart/alternative` message are evaluated independently.

### 2. `reply_all` discarded the References chain

`buildReferencesHeader()` combined the original `References` with the original `Message-ID`, but the result was never placed in `emailArgs`. Since `inReplyTo` *was* set, `handleEmailAction()`'s thread-based header resolution was skipped, and the builders fell back to `references = inReplyTo`. On deep threads the chain collapsed to a single Message-ID and clients lost the conversation grouping.

`buildReferencesHeader()` itself was already covered by tests — only the wiring was missing, which is why the suite stayed green.

### 3. Tool failures were indistinguishable from successes

Errors were returned as ordinary text content without `isError: true`. A client that checks the flag reads `"Error: Failed to send..."` as a successful tool result, so an agent can proceed believing a message was sent. Fixed in the catch-all handler, the scope-denied early return, and both download handlers.

### 4. OAuth listener could hang, and had no `state`

`server.listen()` was called with no `error` handler, so a bind failure (`EADDRINUSE`, or a privileged port when the callback URL is portless) never settled the promise — `auth` hung silently. A failed token exchange rejected without closing the server.

Every exit path now settles exactly once and closes the listener, bind errors reject with an actionable message, and a random `state` is generated and verified so an authorization response that does not match is rejected.

### 5. Reply-all CC contained the sender and duplicates

CC was built from the original To + CC filtered only against the authenticated user. When the sender also appeared in To or CC — routine on mailing lists — the same address landed in both To and CC. Addresses present in both original headers were emitted twice.

CC now excludes everyone already in To and is de-duplicated case-insensitively.

### 6. `get_or_create_label` never reported a creation

The branch tested `result.type === 'user' && result.name === args.name`, which is equally true of a label just created, so the response always said "found existing". `getOrCreateLabel()` now returns `{ label, created }`.

### 7. `create_filter` promised forwarding it could not perform

The schema accepts `action.forward`, but the tool requires only `gmail.settings.basic`. The Gmail API needs `gmail.settings.sharing` for filters with a forwarding action, so such a call failed with an opaque 403. The scope is now checked before the API call with a message naming the required scope, and the schema documents it. Filters without `forward` are unaffected.

### 8. Legacy credentials comment was wrong

Credentials written before scope persistence carry no scope record and fall back to `DEFAULT_SCOPES` (`gmail.modify` + `gmail.settings.basic`), which the comment described as "full access" — it is not, and it may not match what the stored token was actually granted, so tool exposure can diverge from real capability.

The behaviour is unchanged deliberately: downgrading these users to read-only would silently remove send and filter tools from working setups. The comment is corrected and a warning is written to **stderr** (never stdout — that is the MCP stdio channel) suggesting re-authentication.

## Tests

`npm test` — **162 passed / 8 files**, including 14 new cases:

- base64 round-trip for non-ASCII plain and HTML bodies
- ASCII bodies still emitted as `7bit`
- per-part encoding in `multipart/alternative`
- base64 line wrapping at 76 characters
- sender excluded from CC (including case-insensitively) and CC de-duplication
- source check that `reply_all` forwards the References chain

`npm run typecheck` and `npm run build` both pass. Each commit is green on its own.

## Notes

- No dependency, version or packaging changes.
- No deliberate timeout was added to the OAuth flow: the hang this fixes is a bind failure, and a timer would cut off users who take their time at the consent screen.
